### PR TITLE
feat: upgrade node version to alpine3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:alpine
+FROM node:alpine3.12
 RUN apk add yarn
 RUN yarn --version


### PR DESCRIPTION
upgrade node base version from 13.3.0 to 14.4.0
`error autoprefixer@9.8.2: The engine "node" is incompatible with this module. Expected version "^6 || ^8 || ^10 || ^12 || >=13.7". Got "13.3.0"`